### PR TITLE
refactor translator/implement all languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bower_components
 public/lib
 .idea
 
+# config files
+server/config.js
+
 # Floobits
 .floo
 .flooignore

--- a/db/db.js
+++ b/db/db.js
@@ -1,7 +1,6 @@
 var mongoose = require('mongoose');
 var config = require('../server/config.js')
 
-var 
 var dbPath = process.env.MONGODB_URI || config.localDevPath;
 mongoose.connect(dbPath);
 

--- a/db/db.js
+++ b/db/db.js
@@ -1,7 +1,8 @@
 var mongoose = require('mongoose');
+var config = require('../server/config.js')
 
-var devPath = 'mongodb://localhost:27017/linguist';
-var dbPath = process.env.MONGODB_URI || devPath;
+var 
+var dbPath = process.env.MONGODB_URI || config.localDevPath;
 mongoose.connect(dbPath);
 
 var db = mongoose.connection;

--- a/db/db.js
+++ b/db/db.js
@@ -1,11 +1,11 @@
-//var mongoose = require('mongoose');
-//
-//var devPath = 'mongodb://localhost:27017/linguist';
-//var dbPath = process.env.MONGODB_URI || devPath;
-//mongoose.connect(dbPath);
-//
-//var db = mongoose.connection;
-//db.on('error', console.error.bind(console, 'connection error: '));
-//db.once('open', function(){ console.log('Mongodb connection is open!')});
-//
-//module.exports = db;
+var mongoose = require('mongoose');
+
+var devPath = 'mongodb://localhost:27017/linguist';
+var dbPath = process.env.MONGODB_URI || devPath;
+mongoose.connect(dbPath);
+
+var db = mongoose.connection;
+db.on('error', console.error.bind(console, 'connection error: '));
+db.once('open', function(){ console.log('Mongodb connection is open!')});
+
+module.exports = db;

--- a/db/models/Room.js
+++ b/db/models/Room.js
@@ -1,7 +1,8 @@
 var mongoose = require('mongoose');
 var Room = mongoose.Schema({
   room: String,
-  lang:[]
+  lang:[],
+  connections: {type: Number, default: 0} 
 });
 
 module.exports = mongoose.model('Rooms', Room);

--- a/public/client/collections/Messages.js
+++ b/public/client/collections/Messages.js
@@ -15,7 +15,4 @@ var Messages = Backbone.Collection.extend({
     this.add(something);
   }
 
-  //TODO: ajax post to translate server
-  // translate: function(){}
-
 });

--- a/public/client/models/Message.js
+++ b/public/client/models/Message.js
@@ -5,6 +5,6 @@ var Message = Backbone.Model.extend({
     text: '',
     room:'',
     lang: 'en',
-    translations: []
+    translations: {}
   }
 });

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,4 @@
+var config = {}
+config.client_id = "linguistHRR3";
+config.client_secret = "ucpusUg1TmtwCwva9jOCZXTtAoqhpbNaPb0fwU3plrk=";
+module.exports = config;

--- a/server/config.js
+++ b/server/config.js
@@ -1,4 +1,0 @@
-var config = {}
-config.client_id = "linguistHRR3";
-config.client_secret = "ucpusUg1TmtwCwva9jOCZXTtAoqhpbNaPb0fwU3plrk=";
-module.exports = config;

--- a/server/server.js
+++ b/server/server.js
@@ -46,9 +46,8 @@ io.on('connection', function(socket){
         console.log(room.lang.length);
         translator.translate(msg, room, function(err, results){
           msg.translations = results;
-          console.log(msg.translations, ' results from mstranslator');
           socket.join(msg.room);
-          console.log(msg, 'msg broadcasted')
+          console.log('broadcasted message: ', msg);
           io.to(msg.room).emit('chat message', msg);
         });
       });

--- a/server/server.js
+++ b/server/server.js
@@ -18,8 +18,9 @@ var translator = require('./translator.js');
 app.use(express.static(indexPage));
 
 io.on('connection', function(socket){
+  //automatically connect new users to lobby
   socket.join('lobby');
- //console.log('a user connected!');
+  //console.log('a user connected!');
   socket.on('disconnect', function(){
     //console.log('user disconnected');
   });

--- a/server/server.js
+++ b/server/server.js
@@ -12,10 +12,7 @@ var Rooms = require('../db/models/Room.js');
 var config = require('./config.js') || {};
 
 var indexPage = path.resolve(__dirname + '../../public');
-var bingtoken = process.env.TOKEN || config.accessToken;
-var accessToken = encodeURIComponent(bingtoken);
-var msTranslator = require('mstranslator');
-var async = require('async');
+
 var translator = require('./translator.js');
 
 app.use(express.static(indexPage));
@@ -50,6 +47,7 @@ io.on('connection', function(socket){
           msg.translations = results;
           console.log(msg.translations, ' results from mstranslator');
           socket.join(msg.room);
+          console.log(msg, 'msg broadcasted')
           io.to(msg.room).emit('chat message', msg);
         });
       });
@@ -59,16 +57,16 @@ io.on('connection', function(socket){
   socket.on('leave room', function(room){
     // console.log(socket.adapter.rooms);
     socket.leave(room);
-   // console.log('leaving room ->', room);
-   // console.log('elvis has left the building!');
-   // console.log(socket.adapter.rooms);
+    // console.log('leaving room ->', room);
+    // console.log('elvis has left the building!');
+    // console.log(socket.adapter.rooms);
   });
 
   socket.on('join room', function(room){
     // console.log(socket.adapter.rooms);
     socket.join(room);
-   // console.log('enter room ->', room);
-   // console.log(socket.adapter.rooms);
+    // console.log('enter room ->', room);
+    // console.log(socket.adapter.rooms);
   });
 
 });

--- a/server/translator.js
+++ b/server/translator.js
@@ -1,4 +1,5 @@
 var msTranslator = require('mstranslator');
+var config = require('./config.js')
 
 var makeTranslateQuery = function(text, fromLang, toLang){
   var params = {
@@ -8,8 +9,8 @@ var makeTranslateQuery = function(text, fromLang, toLang){
   }
   return function(callback){
     var client =  new msTranslator({
-      client_id:  "linguistHRR3",
-      client_secret: "ucpusUg1TmtwCwva9jOCZXTtAoqhpbNaPb0fwU3plrk="
+      client_id:  config.client_id,
+      client_secret: config.client_secret
     }, true);
     client.translate (params, function (err , data) {
       console.log (params.to, 'returned data');

--- a/server/translator.js
+++ b/server/translator.js
@@ -1,0 +1,27 @@
+var msTranslator = require('mstranslator');
+
+var makeTranslateQuery = function(text, fromLang, toLang){
+  var params = {
+    text: text,
+    from: fromLang,
+    to: toLang
+  }
+  return function(callback){
+    var client =  new msTranslator({
+      client_id:  "linguistHRR3",
+      client_secret: "ucpusUg1TmtwCwva9jOCZXTtAoqhpbNaPb0fwU3plrk="
+    }, true);
+    client.translate (params, function (err , data) {
+      console.log (params.to, 'returned data');
+      if(err){
+        console.log(err)
+      }
+      else{
+        var arrData = [data , params.to];
+        callback (err , arrData);
+      }
+    });
+  };
+}
+
+module.exports = makeTranslateQuery;

--- a/server/translator.js
+++ b/server/translator.js
@@ -24,8 +24,8 @@ Translator.prototype.makeTranslateQuery = function(text, fromLang, toLang){
   };
   return function(callback){
     var client =  new msTranslator({
-      client_id:  config.client_id,
-      client_secret: config.client_secret
+      client_id: process.env.CLIENT_ID || config.client_id,
+      client_secret: process.env.CLIENT_SECRET || config.client_secret
     }, true);
     client.translate (params, function (err , data) {
       console.log (params.to, 'returned data');

--- a/server/translator.js
+++ b/server/translator.js
@@ -5,17 +5,21 @@ var async = require('async');
 
 var Translator = function(){};
 
+// This generates translate functions for all languages in specified room,
+// calls them in parallel, and executes callback on the results.
 Translator.prototype.translate = function(msg, room, callback){
-  var tasks = [];
+  var tasks = {};
   for(var i = 0; i < room.lang.length; i++){
     console.log(room.lang[i], ' from translate function');
-    tasks[i] = this.makeTranslateQuery(msg.text, msg.lang, room.lang[i]);
+    tasks[room.lang[i]] = this.makeTranslateQuery(msg.text, msg.lang, room.lang[i]);
   }
   async.parallel(tasks, function(err, results){
     callback(err, results);
   })
 };
 
+// this returns a function ready to be called with parameters set to
+// values passed in. 
 Translator.prototype.makeTranslateQuery = function(text, fromLang, toLang){
   var params = {
     text: text,
@@ -28,13 +32,11 @@ Translator.prototype.makeTranslateQuery = function(text, fromLang, toLang){
       client_secret: process.env.CLIENT_SECRET || config.client_secret
     }, true);
     client.translate (params, function (err , data) {
-      console.log (params.to, 'returned data');
       if(err){
         console.log(err)
       }
       else{
-        var arrData = [data , params.to];
-        callback (err , arrData);
+        callback (err, data);
       }
     });
   };

--- a/server/translator.js
+++ b/server/translator.js
@@ -1,12 +1,27 @@
 var msTranslator = require('mstranslator');
-var config = require('./config.js')
+var config = require('./config.js');
+var async = require('async');
 
-var makeTranslateQuery = function(text, fromLang, toLang){
+
+var Translator = function(){};
+
+Translator.prototype.translate = function(msg, room, callback){
+  var tasks = [];
+  for(var i = 0; i < room.lang.length; i++){
+    console.log(room.lang[i], ' from translate function');
+    tasks[i] = this.makeTranslateQuery(msg.text, msg.lang, room.lang[i]);
+  }
+  async.parallel(tasks, function(err, results){
+    callback(err, results);
+  })
+};
+
+Translator.prototype.makeTranslateQuery = function(text, fromLang, toLang){
   var params = {
     text: text,
     from: fromLang,
     to: toLang
-  }
+  };
   return function(callback){
     var client =  new msTranslator({
       client_id:  config.client_id,
@@ -23,6 +38,6 @@ var makeTranslateQuery = function(text, fromLang, toLang){
       }
     });
   };
-}
+};
 
-module.exports = makeTranslateQuery;
+module.exports = new Translator();


### PR DESCRIPTION
CHANGES:
- Implemented db, will track rooms and what languages are in rooms
- Refactored translation function into translator.js
  - will only send out requests for languages in room
  - server supports all languages from mstranslate now
- Changed server response msg.translation from array to object with this syntax: { language : translation }
- Changed backbone model to account for msg.translation obj format

ISSUES:
- Need to make client display translations
- Need to remove languages from rooms when users leave
- Need to delete rooms when empty
- Have client send empty obj with client language on joining server 

Requirements to run:
- Needs a mongodb server with client info set to process.env.MONGODB_URI to run in deployment
- Requires server/config.js to run in development mode, contents:
  
  var config = {}
  config.client_id = "id";
  config.client_secret = "secret";
  config.localDevPath = 'mongodb://localhost:27017/linguist';
  module.exports = config;
